### PR TITLE
Update `FuzzyTokenSearcher` to be more exhaustive

### DIFF
--- a/fuzzy_search/match/phrase_match.py
+++ b/fuzzy_search/match/phrase_match.py
@@ -91,15 +91,15 @@ def validate_match_props(match_phrase: Phrase, match_variant: Phrase,
     :rtype: None
     """
     if not isinstance(match_phrase, Phrase):
-        print(match_phrase)
-        print(type(match_phrase))
+        print(f"match_phrase: {match_phrase}")
+        print(f"type: {type(match_phrase)}")
         raise TypeError('match_phrase MUST be of class Phrase')
     if not isinstance(match_variant, Phrase):
         raise TypeError('match_variant MUST be of class Phrase')
     if not isinstance(match_string, str):
         raise TypeError('match string MUST be a string')
     if len(match_string) == 0:
-        print(match_phrase)
+        print(f"match_phrase: {match_phrase}")
         raise ValueError('match string cannot be empty string')
     if not isinstance(match_offset, int):
         raise TypeError('match_offset must be an integer')
@@ -828,10 +828,10 @@ class PartialPhraseMatch:
         self.text_tokens = tuple(text_tokens)
         # self.text_tokens = tuple([token for match in self.token_matches for token in match.text_tokens])
         self.phrase_tokens = tuple([token for match in self.token_matches for token in match.phrase_tokens])
-        self.first = self.text_tokens[0]
-        self.last = self.text_tokens[-1]
-        self.text_start = self.first.char_index
-        self.text_end = self.last.char_index + len(self.last)
+        self.first_text_token = self.text_tokens[0]
+        self.last_text_token = self.text_tokens[-1]
+        self.text_start = self.first_text_token.char_index
+        self.text_end = self.last_text_token.char_index + len(self.last_text_token)
         self.text_length = self.text_end - self.text_start
 
     def pop(self):
@@ -867,3 +867,20 @@ class PartialPhraseMatch:
                     self.missing_tokens.remove(phrase_token)
         self.token_matches.extend(token_matches)
         self._update()
+
+
+def copy_partial_match(partial_match: PartialPhraseMatch):
+    new_pm = PartialPhraseMatch(phrase=partial_match.phrase, token_matches=None,
+                                max_char_gap=partial_match.max_char_gap,
+                                max_token_gap=partial_match.max_token_gap)
+    new_pm.token_matches = [tm for tm in partial_match.token_matches]
+    new_pm.missing_tokens = [token for token in partial_match.missing_tokens]
+    new_pm.text_tokens = [token for token in partial_match.text_tokens]
+    new_pm.phrase_tokens = [token for token in partial_match.phrase_tokens]
+    new_pm.redundant_tokens = [token for token in partial_match.redundant_tokens]
+    new_pm.first_text_token = partial_match.first_text_token
+    new_pm.last_text_token = partial_match.last_text_token
+    new_pm.text_start = partial_match.text_start
+    new_pm.text_end = partial_match.text_end
+    new_pm.text_length = partial_match.text_length
+    return new_pm

--- a/fuzzy_search/phrase/phrase.py
+++ b/fuzzy_search/phrase/phrase.py
@@ -190,6 +190,12 @@ class Phrase:
         self.max_end_offset = max_end_offset
         self.max_end_start = self.max_end_offset - len(self.phrase_string)
 
+    def has_max_start_offset(self) -> bool:
+        return self.max_start_offset is not None and self.max_start_offset >= 0
+
+    def has_max_end_offset(self) -> bool:
+        return self.max_end_offset is not None and self.max_end_offset >= 0
+
     def has_skipgram(self, skipgram: str) -> bool:
         """For a given skipgram, return boolean whether it is in the index
 

--- a/fuzzy_search/search/token_searcher.py
+++ b/fuzzy_search/search/token_searcher.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import copy
 import time
 from collections import defaultdict
 from typing import Dict, List, Union
@@ -8,6 +10,7 @@ from fuzzy_search.match.phrase_match import PhraseMatch
 from fuzzy_search.match.phrase_match import MatchType
 from fuzzy_search.match.phrase_match import TokenMatch
 from fuzzy_search.match.phrase_match import PartialPhraseMatch
+from fuzzy_search.match.phrase_match import copy_partial_match
 from fuzzy_search.match.skip_match import SkipMatches
 from fuzzy_search.phrase.phrase_model import PhraseModel
 from fuzzy_search.search.searcher import FuzzySearcher
@@ -44,11 +47,17 @@ def map_text_tokens_to_phrase_tokens(partial_match: PartialPhraseMatch) -> Union
 def get_partial_phrases(token_matches: List[TokenMatch], token_searcher: FuzzyTokenSearcher,
                         max_char_gap: int = 20, debug: int = 0):
     partial_phrase: Dict[Phrase, PartialPhraseMatch] = {}
-    partial_phrases = {}
     candidate_phrase: Dict[Phrase, List[PartialPhraseMatch]] = defaultdict(list)
     prev_token_match = None
+    if debug > 1:
+        print(f"token_searcher.get_partial_phrases")
     for token_match in token_matches:
         if prev_token_match and token_match.text_start - prev_token_match.text_end > max_char_gap:
+            if debug > 1:
+                gap = token_match.text_start - prev_token_match.text_end
+                print(f"    gap between prev_token_match and token_match ({gap}) "
+                      f"bigger than max_char_gap {max_char_gap}")
+                print(f"      emptying partial_phrase {partial_phrase}")
             partial_phrase: Dict[Phrase, PartialPhraseMatch] = {}
         if debug > 1:
             print(
@@ -64,11 +73,11 @@ def get_partial_phrases(token_matches: List[TokenMatch], token_searcher: FuzzyTo
                     continue
                 # print('phrase:', phrase)
                 # print('phrase.tokens:', phrase.tokens)
-                if debug > 1:
+                if debug > 1 and phrase is not None:
                     print('\t\tphrase:', phrase)
                 if phrase not in candidate_phrase:
                     if debug > 1:
-                        print('\t\t\tADDING PHRASE')
+                        print('\t\t\tADDING PHRASE AND APPENDING PARTIAL')
                     partial = PartialPhraseMatch(phrase, [token_match])
                     # partial_phrase[phrase] = partial
                     candidate_phrase[phrase].append(partial)
@@ -79,37 +88,62 @@ def get_partial_phrases(token_matches: List[TokenMatch], token_searcher: FuzzyTo
                         if token_match.text_start - partial.text_end > max_char_gap:
                             # print('skipping partial match:', token_match.text_start, partial.text_end)
                             continue
+                        if debug > 1:
+                            print(f"TEST partial.text_end: {partial.text_end} "
+                                  f"token_match.text_start: {token_match.text_start}")
+                            print(f"    partial.missing_tokens: {partial.missing_tokens}")
+                            print(f"    token_match.phrase_tokens: {token_match.phrase_tokens}")
                         if partial.text_end < token_match.text_start and \
                                 any([pt for pt in token_match.phrase_tokens if pt in partial.missing_tokens]):
-                            partial.add_tokens([token_match])
-                            if debug > 1:
-                                print('\t\t\tADDING TOKEN')
-                                print('\t\t', partial.text_tokens)
-                                print('\t\t', partial.text_start, partial.text_end)
-                                print('\t\t', partial.text_length, len(phrase))
-                            added = True
+                            partial_copy = copy_partial_match(partial)
+                            partial_copy.add_tokens([token_match])
+                            if partial_copy.text_length - len(phrase) <= token_searcher.config['max_length_variance']:
+                                candidate_phrase[phrase].append(partial_copy)
+                                if debug > 1:
+                                    print('\t\t\tADDING TOKEN TO COPY OF PARTIAL')
+                                    print('\t\t', partial_copy.text_tokens)
+                                    print('\t\t', partial_copy.text_start, partial_copy.text_end)
+                                    print('\t\t', partial_copy.text_length, len(phrase))
+                                added = True
                     if not added:
                         partial = PartialPhraseMatch(phrase, [token_match])
                         if debug > 1:
-                            print('\t\t\tADDING PARTIAL TO PHRASE')
+                            print('\t\t\tADDING AS NEW PARTIAL TO PHRASE')
                             print('\t\t', partial.text_tokens)
                             print('\t\t', partial.text_start, partial.text_end)
                             print('\t\t', partial.text_length, len(phrase))
                         candidate_phrase[phrase].append(partial)
+            if debug > 1:
+                print(f"\n--------------\nCANDIDATE PHRASES:")
+                for phrase in candidate_phrase:
+                    print(f"    PHRASE: {phrase}")
+                    for partial in candidate_phrase[phrase]:
+                        print(f"\tPARTIAL: {partial.text_tokens}, {partial.phrase_tokens}\t "
+                              f"RANGE: {partial.text_start}-{partial.text_end}\t"
+                              f"MISSING: {partial.missing_tokens}")
+                print('---------------')
         prev_token_match = token_match
     for phrase in candidate_phrase:
-        remove_phrases = []
+        remove_partials = []
+        remove_incomplete = False
+        if any([len(partial.missing_tokens) == 0 for partial in candidate_phrase[phrase]]):
+            remove_incomplete = True
         for partial in candidate_phrase[phrase]:
             if debug > 1:
                 print('\tCHECKING PARTIAL CANDIDATE')
                 print('\t\t', partial.text_tokens)
                 print('\t\t', partial.text_start, partial.text_end)
                 print('\t\t', partial.text_length, len(phrase))
-            if abs(partial.text_length - len(phrase)) > token_searcher.config['max_length_variance']:
+            if remove_incomplete is True and len(partial.missing_tokens) > 0:
+                if debug > 1:
+                    print("\t\tREMOVE CANDIDATE BECAUSE IT'S INCOMPLETE!")
+                remove_partials.append(partial)
+                # candidate_phrase[phrase].remove(partial)
+            elif abs(partial.text_length - len(phrase)) > token_searcher.config['max_length_variance']:
                 if debug > 0:
                     print('\t\tREMOVE CANDIDATE!')
-                remove_phrases.append(partial)
-                candidate_phrase[phrase].remove(partial)
+                remove_partials.append(partial)
+                # candidate_phrase[phrase].remove(partial)
                 # candidate_phrase.append(partial)
                 # del partial
             # elif partial.text_length > len(phrase) + token_searcher.config['max_length_variance']:
@@ -117,6 +151,8 @@ def get_partial_phrases(token_matches: List[TokenMatch], token_searcher: FuzzyTo
                 if debug > 0:
                     print('\t\tCANDIDATE FOUND!')
                 # del partial[phrase]
+        for partial in remove_partials:
+            candidate_phrase[phrase].remove(partial)
     return candidate_phrase
 
 
@@ -159,13 +195,26 @@ def get_text_string(text: Union[str, Dict[str, any], Doc]) -> str:
             f'invalid text type {type(text)}, must be string, Doc or a dictionary with "text" and "id" properties')
 
 
-def get_token_skipgram_matches(text_token_skips: List[SkipGram], token_searcher: FuzzyTokenSearcher,
+def get_token_skipgram_matches(text_token: Token, text_token_skips: List[SkipGram],
+                               token_searcher: FuzzyTokenSearcher,
                                debug: int = 0):
     token_skip_matches = SkipMatches(token_searcher.ngram_size, token_searcher.skip_size)
     for skipgram in text_token_skips:
         for phrase_token in token_searcher.token_skipgram_index[skipgram.string]:
+            if phrase_token in token_searcher.phrase_model.phrase_token_max_start_offset:
+                max_token_offset = token_searcher.phrase_model.phrase_token_max_start_offset[phrase_token]
+                if text_token.char_index > max_token_offset:
+                    continue
             token_skip_matches.add_skip_match(skipgram, phrase_token)
     return token_skip_matches
+
+
+def has_max_start_offset(phrase: Phrase):
+    return phrase.max_start_offset is not None and phrase.max_start_offset != -1
+
+
+def has_max_end_offset(phrase: Phrase):
+    return phrase.max_end_offset is not None and phrase.max_end_offset != -1
 
 
 class FuzzyTokenSearcher(FuzzySearcher):
@@ -202,6 +251,8 @@ class FuzzyTokenSearcher(FuzzySearcher):
         self.token_num_skips = {}
         self.max_token_gap = max_token_gap
         self.max_char_gap = max_char_gap
+        if 'max_token_length_variance' not in self.config:
+            self.config['max_token_length_variance'] = self.config['max_length_variance']
         self.vocabulary = vocabulary
         if debug > 3:
             print(f'{self.__class__.__name__}.index_phrase_model - calling index_token_skipgrams()')
@@ -246,7 +297,7 @@ class FuzzyTokenSearcher(FuzzySearcher):
                 self.find_vocabulary_token_matches_for_token(text_token, token_matches, debug=debug)
                 continue
             if debug > 0:
-                print('\nfind_skipgram_token_matches_in_text - text_token:', text_token)
+                print('\n  find_skipgram_token_matches_in_text - text_token:', text_token)
             self.find_skipgram_token_matches_for_token(text_token, partial_matches, token_matches, debug=debug)
         return token_matches
 
@@ -257,6 +308,8 @@ class FuzzyTokenSearcher(FuzzySearcher):
         for phrase_string in self.phrase_model.token_in_phrase[text_token.n]:
             phrase = self.phrase_model.get_phrase(phrase_string)
             if isinstance(phrase, Phrase):
+                if token_is_out_of_phrase_range(text_token, phrase, self):
+                    continue
                 phrase_tokens = [token for token in phrase.tokens if token.n == text_token.n]
                 token_match = TokenMatch(text_tokens=text_token, phrase_tokens=phrase_tokens,
                                          match_type=MatchType.FULL)
@@ -276,24 +329,24 @@ class FuzzyTokenSearcher(FuzzySearcher):
         :type debug: int
         """
         if debug > 0:
-            print(f'\nfind_skipgram_token_matches - text_token: {text_token}')
-        text_token_skips = [skipgram for skipgram in text2skipgrams(text_token.normalised_string,
-                                                                    self.ngram_size,
+            print(f'\n    find_skipgram_token_matches_for_token - text_token: {text_token}')
+        text_token_skips = [skipgram for skipgram in text2skipgrams(text_token.n, self.ngram_size,
                                                                     self.skip_size)]
-        token_skip_matches = get_token_skipgram_matches(text_token_skips, self)
         if debug > 0:
-            print(f'find_skipgram_token_matches - number of phrase matches: '
+            print(f'\n    find_skipgram_token_matches_for_token - text_token skips: {text_token_skips}')
+        token_skip_matches = get_token_skipgram_matches(text_token, text_token_skips, self)
+        if debug > 0:
+            print(f'    find_skipgram_token_matches_for_token - number of phrase matches: '
                   f'{len(token_skip_matches.match_start_offsets)}')
             print()
         text_token_num_skips = len(text_token_skips)
         token_match_types = set()
-        for phrase_token_match in token_skip_matches.match_start_offsets:
+        for pmi, phrase_token_match in enumerate(token_skip_matches.match_start_offsets):
             if debug > 1:
-                print(f'\n\tfind_skipgram_token_matches - phrase_token_match: {phrase_token_match}')
-                print(f'\tfind_skipgram_token_matches - phrase_token_match: {phrase_token_match}')
-                print(f'\tfind_skipgram_token_matches - number of skipgram matches: '
+                print(f'\n    find_skipgram_token_matches_for_token - phrase_token_match {pmi+1}: {phrase_token_match}')
+                print(f'    find_skipgram_token_matches_for_token - number of skipgram matches: '
                       f'{len(token_skip_matches.match_start_offsets[phrase_token_match])}')
-                print(f'\tfind_skipgram_token_matches - skipgram matches: ',
+                print(f'    find_skipgram_token_matches_for_token - skipgram matches: ',
                       token_skip_matches.match_skipgrams[phrase_token_match][0].start_offset,
                       token_skip_matches.match_skipgrams[phrase_token_match][-1].end_offset,
                       )
@@ -302,20 +355,20 @@ class FuzzyTokenSearcher(FuzzySearcher):
                                                    token_skip_matches,
                                                    phrase_token_match, self, debug=debug)
             if debug > 2:
-                print(f'\tfind_skipgram_token_matches - match_type: {match_type}')
+                print(f'    find_skipgram_token_matches - match_type: {match_type}')
             token_match_types.add(match_type)
             if match_type == MatchType.NONE:
                 continue
             elif match_type == MatchType.FULL:
                 token_match = TokenMatch(text_token, phrase_token_match, match_type)
                 if debug > 2:
-                    print(f'\n\tfind_skipgram_token_matches - adding full match: {token_match}\n')
+                    print(f'\n    find_skipgram_token_matches - adding full match: {token_match}\n')
                 token_matches.append(token_match)
                 if debug > 0:
                     print('NUMBER OF TOKEN MATCHES:', len(token_matches))
             elif match_type == MatchType.PARTIAL_OF_PHRASE_TOKEN:
                 if debug > 2:
-                    print(f'\t\tfind_skipgram_token_matches - partial_matches: {partial_matches}')
+                    print(f'\tfind_skipgram_token_matches - partial_matches: {partial_matches}')
                 if phrase_token_match in partial_matches:
                     if debug > 2:
                         print(phrase_token_match)
@@ -323,48 +376,49 @@ class FuzzyTokenSearcher(FuzzySearcher):
                         print(partial_matches[phrase_token_match])
                     last_partial = partial_matches[phrase_token_match][-1]
                     if debug > 2:
-                        print(f'\t\tfind_skipgram_token_matches - last_partial: {last_partial}')
+                        print(f'\tfind_skipgram_token_matches - last_partial: {last_partial}')
                     if text_token.char_index - (last_partial.char_index + len(last_partial)) > 4:
                         if debug > 2:
-                            print(f'\t\t\tfind_skipgram_token_matches - text_token.char_index: {text_token.char_index}')
-                            print(f'\t\t\tfind_skipgram_token_matches - end of last_partial: '
+                            print(f'\t\tfind_skipgram_token_matches - text_token.char_index: {text_token.char_index}')
+                            print(f'\t\tfind_skipgram_token_matches - end of last_partial: '
                                   f'{last_partial.char_index + len(last_partial)}')
-                            print(f'\t\t\tfind_skipgram_token_matches - removing partial_match for phrase token: '
+                            print(f'\t\tfind_skipgram_token_matches - removing partial_match for phrase token: '
                                   f'{phrase_token_match}')
                         del partial_matches[phrase_token_match]
                 if debug > 2:
-                    print(f'\t\tfind_skipgram_token_matches - adding partial "{text_token}" '
+                    print(f'\tfind_skipgram_token_matches - adding partial "{text_token}" '
                           f'of phrase token "{phrase_token_match}"')
                 partial_matches[phrase_token_match].append(text_token)
                 if len(partial_matches[phrase_token_match]) > 1:
                     if debug > 2:
-                        print(f'\t\t\tfind_skipgram_token_matches - checking if partial_matches align with '
+                        print(f'\t\tfind_skipgram_token_matches - checking if partial_matches align with '
                               f'phrase token: {partial_matches[phrase_token_match]}')
                     first_partial = partial_matches[phrase_token_match][0]
                     last_partial = partial_matches[phrase_token_match][-1]
                     partial_length = last_partial.char_index + len(last_partial) - first_partial.char_index
                     length_diff = partial_length - len(phrase_token_match)
                     if debug > 2:
-                        print(f'\t\t\tfind_skipgram_token_matches - partial_matches: {partial_matches[phrase_token_match]}')
-                        print(f'\t\t\tfind_skipgram_token_matches - partial_length: {partial_length}')
-                        print(f'\t\t\tfind_skipgram_token_matches - phrase_token length: {phrase_token_match}')
-                        print(f'\t\t\tfind_skipgram_token_matches - lenght_diff: {length_diff}')
+                        print(f'\t\tfind_skipgram_token_matches - '
+                              f'partial_matches: {partial_matches[phrase_token_match]}')
+                        print(f'\t\tfind_skipgram_token_matches - partial_length: {partial_length}')
+                        print(f'\t\tfind_skipgram_token_matches - phrase_token length: {phrase_token_match}')
+                        print(f'\t\tfind_skipgram_token_matches - lenght_diff: {length_diff}')
 
-                    if length_diff > 0 or abs(length_diff) <= self.config['max_length_variance']:
+                    if length_diff > 0 or abs(length_diff) <= self.config['max_token_length_variance']:
                         token_match = TokenMatch(partial_matches[phrase_token_match],
                                                  phrase_token_match, match_type)
                         token_matches.append(token_match)
                         if debug > 0:
                             print('NUMBER OF TOKEN MATCHES:', len(token_matches))
                         if debug > 2:
-                            print(f'\n\tfind_skipgram_token_matches - adding full match: {token_match}')
+                            print(f'\n    find_skipgram_token_matches - adding full match: {token_match}')
                         partial_matches[phrase_token_match].pop(0)
             elif match_type == MatchType.PARTIAL_OF_TEXT_TOKEN:
                 token_match = TokenMatch(text_token, phrase_token_match, match_type)
                 token_matches.append(token_match)
         if MatchType.PARTIAL_OF_PHRASE_TOKEN not in token_match_types:
             if debug > 2:
-                print(f'\tfind_skipgram_token_matches - emptying partial_matches')
+                print(f'    find_skipgram_token_matches - emptying partial_matches')
             partial_matches = defaultdict(list)
         if debug > 1:
             print(partial_matches, '\n')
@@ -372,46 +426,68 @@ class FuzzyTokenSearcher(FuzzySearcher):
     def _pick_best_candidates(self, doc: Doc, candidate_phrases: Dict[Phrase, List[PartialPhraseMatch]],
                               debug: int = 0):
         if debug > 0:
-            print('\nfind_phrase_matches - listing partial matches:')
+            print('\n  _pick_best_candidates - listing partial matches:')
             for phrase in candidate_phrases:
-                print('\tfind_phrase_matches - phrase:', phrase)
+                print('    _pick_best_candidates - phrase:', phrase)
                 for partial in candidate_phrases[phrase]:
-                    print('\t\tfind_phrase_matches - partial:', partial)
+                    print('\t_pick_best_candidates - partial:', partial)
         phrase_at_offset: Dict[int, PartialPhraseMatch] = {}
         for phrase in candidate_phrases:
             for pp in candidate_phrases[phrase]:
-                pp.match_string = doc.text[pp.text_start:pp.text_end]
+                full_match_string = doc.text[pp.text_start:pp.text_end]
+                full_text_length = pp.text_end - pp.text_start
                 # the match_string is only the text tokens, not the text between
                 # start and end offsets: if there are non-matching tokens in between,
                 # the Levenshtein score should be computed only on the matching text
                 # tokens.
                 pp.match_string = ' '.join([token.n for token in pp.text_tokens])
                 if debug > 0:
-                    print('\nfind_phrase_matches - pp:', pp.phrase.phrase_string)
-                    print('\tfind_phrase_matches - pp.match_string:', pp.match_string)
+                    print('\n    _pick_best_candidates - pp:', pp.phrase.phrase_string)
+                    print('\t_pick_best_candidates - pp.match_string:', pp.match_string)
                 if abs(len(pp.match_string) - len(pp.phrase.phrase_string)) > self.max_length_variance:
-                    continue
+                    if abs(full_text_length - len(pp.phrase.phrase_string)) > self.max_length_variance:
+                        if debug > 0:
+                            print(f"      length difference above max length variance")
+                        continue
+                    else:
+                        if debug > 0:
+                            print(f"      length difference above max length variance, but full text length below")
                 pp.levenshtein_score = score_levenshtein_similarity_ratio(pp.phrase.phrase_string, pp.match_string)
                 if debug > 1:
-                    print('\tfind_phrase_matches - pp.levenshtein_score:', pp.levenshtein_score)
+                    print('\t_pick_best_candidates - pp.levenshtein_score:', pp.levenshtein_score)
                 if pp.levenshtein_score < self.config['levenshtein_threshold']:
                     if debug > 0:
-                        print(f'\t\tfind_phrase_matches - phrase below score threshold {pp.text_start}:', pp.phrase.phrase_string)
+                        print(f'\t\t_pick_best_candidates - phrase below '
+                              f'score threshold {pp.text_start}:', pp.phrase.phrase_string)
                     continue
                 if pp.text_start in phrase_at_offset:
                     if debug > 0:
-                        print(f'\t\tfind_phrase_matches - next phrase at offset {pp.text_start}:', pp.phrase.phrase_string)
+                        print(f'\t\t_pick_best_candidates - next phrase at '
+                              f'offset {pp.text_start}:', pp.phrase.phrase_string)
                     if pp.levenshtein_score > phrase_at_offset[pp.text_start].levenshtein_score:
                         if debug > 0:
-                            print(f'\t\tfind_phrase_matches - replacing phrase at offset {pp.text_start}:', pp.phrase.phrase_string)
+                            print(f'\t\t_pick_best_candidates - replacing '
+                                  f'phrase at offset {pp.text_start}:', pp.phrase.phrase_string)
                         phrase_at_offset[pp.text_start] = pp
                 else:
                     if debug > 0:
-                        print(f'\t\tfind_phrase_matches - first phrase at offset {pp.text_start}:', pp.phrase.phrase_string)
+                        print(f'\t\t_pick_best_candidates - first phrase at '
+                              f'offset {pp.text_start}:', pp.phrase.phrase_string)
                     phrase_at_offset[pp.text_start] = pp
         phrases = []
         for partial_phrase in sorted(phrase_at_offset.values(), key=lambda x: x.text_start):
-            phrase = PhraseMatch(partial_phrase.phrase, partial_phrase.phrase, partial_phrase.match_string,
+            if partial_phrase.phrase.phrase_string in self.phrase_model.phrase_index:
+                phrase = partial_phrase.phrase
+                variant = phrase
+            elif partial_phrase.phrase.phrase_string in self.phrase_model.variant_index:
+                phrase = self.phrase_model.variant_of(partial_phrase.phrase)
+                variant = partial_phrase.phrase
+            elif partial_phrase.phrase.phrase_string in self.phrase_model.distractor_index:
+                # phrase is a distractor
+                continue
+            else:
+                raise KeyError(f"partial phrase {partial_phrase.phrase} not registered in phrase_model.")
+            phrase = PhraseMatch(phrase, variant, partial_phrase.match_string,
                                  partial_phrase.text_start, text_id=doc.id,
                                  levenshtein_similarity=partial_phrase.levenshtein_score,
                                  match_label=list(partial_phrase.phrase.label_set))
@@ -438,20 +514,22 @@ class FuzzyTokenSearcher(FuzzySearcher):
         """
         start = time.time()
         doc = get_tokenized_doc(text, self.tokenizer)
+        if debug > 0:
+            print('find_matches - checking token matches in text')
         token_matches = self.find_skipgram_token_matches_in_text(doc, debug=debug)
         if debug > 0:
-            print('find_phrase_matches - number of token_matches:', len(token_matches))
+            print('find_matches - number of token_matches:', len(token_matches))
         if debug > 1:
-            print('find_phrase_matches - number of token_matches:', len(token_matches))
             step1 = time.time()
             print(f'step 1 took: {step1 - start: >.2f} seconds')
         if debug > 1:
             for tm in token_matches:
-                print('find_phrase_matches - token_match:', tm)
-        candidate_phrases = get_partial_phrases(token_matches, self)
+                print('find_matches - token_match:', tm)
+        candidate_phrases = get_partial_phrases(token_matches, self, debug=debug)
         if debug > 1:
-            print('find_phrase_matches - number of candidate phrases:', len(candidate_phrases))
-            print('find_phrase_matches - number of partial phrases:', sum([len(candidate_phrases[phrase]) for phrase in candidate_phrases]))
+            print('find_matches - number of candidate phrases:', len(candidate_phrases))
+            print('find_matches - number of partial phrases:',
+                  sum([len(candidate_phrases[phrase]) for phrase in candidate_phrases]))
             step2 = time.time()
             print(f'step 2 took: {step2 - step1: >.2f} seconds')
         matches = self._pick_best_candidates(doc, candidate_phrases, debug=debug)
@@ -459,7 +537,21 @@ class FuzzyTokenSearcher(FuzzySearcher):
         if debug > 1:
             step3 = time.time()
             print(f'step 3 took: {step3 - step2: >.2f} seconds')
-        return matches
+        return filtered_matches
+
+
+def token_is_out_of_phrase_range(token: Token, phrase: Phrase, token_searcher: FuzzyTokenSearcher):
+    assert token.n in token_searcher.phrase_model.min_token_offset_in_phrase
+    assert phrase.phrase_string in token_searcher.phrase_model.min_token_offset_in_phrase[token.n]
+    if has_max_start_offset(phrase):
+        max_token_offset = token_searcher.phrase_model.max_token_offset_in_phrase[token.n][phrase.phrase_string]
+        if token.char_index > phrase.max_start_offset + max_token_offset:
+            return True
+    if has_max_end_offset(phrase):
+        min_token_offset = token_searcher.phrase_model.min_token_offset_in_phrase[token.n][phrase.phrase_string]
+        if token.char_index < phrase.max_end_offset + min_token_offset:
+            return True
+    return False
 
 
 def get_token_skip_match_type(text_token_string: str, text_token_num_skips: int,
@@ -477,33 +569,33 @@ def get_token_skip_match_type(text_token_string: str, text_token_num_skips: int,
     else:
         length_variance = len(phrase_token_match) - (overlap_end - overlap_start)
     if debug > 1:
-        print(f"get_token_skip_match_type - first:", first)
-        print(f"get_token_skip_match_type - last:", last)
-        print(f"get_token_skip_match_type - overlap_start:", overlap_start)
-        print(f"get_token_skip_match_type - overlap_end:", overlap_end)
-        print(f"get_token_skip_match_type - num_skip_matches:", num_skip_matches)
-        print(f"get_token_skip_match_type - text_token_skip_overlap:", text_token_skip_overlap)
-        print(f"get_token_skip_match_type - phrase_token_skip_overlap:", phrase_token_skip_overlap)
-        print(f"get_token_skip_match_type - length_variance:", length_variance)
+        print(f"        get_token_skip_match_type - first:", first)
+        print(f"        get_token_skip_match_type - last:", last)
+        print(f"        get_token_skip_match_type - overlap_start:", overlap_start)
+        print(f"        get_token_skip_match_type - overlap_end:", overlap_end)
+        print(f"        get_token_skip_match_type - num_skip_matches:", num_skip_matches)
+        print(f"        get_token_skip_match_type - text_token_skip_overlap:", text_token_skip_overlap)
+        print(f"        get_token_skip_match_type - phrase_token_skip_overlap:", phrase_token_skip_overlap)
+        print(f"        get_token_skip_match_type - length_variance:", length_variance)
     if text_token_skip_overlap < token_searcher.config['skipgram_threshold'] and \
             phrase_token_skip_overlap < token_searcher.config['skipgram_threshold']:
         match_type = MatchType.NONE
         if debug > 1:
-            print(f"get_token_skip_match_type - below skipgram thresholds, match_type:", match_type)
-    elif length_variance > token_searcher.config['max_length_variance']:
+            print(f"        get_token_skip_match_type - below skipgram thresholds, match_type:", match_type)
+    elif length_variance > token_searcher.config['max_token_length_variance']:
         match_type = MatchType.NONE
         if debug > 1:
-            print(f"get_token_skip_match_type - above max length variance, match_type:", match_type)
-    elif abs(len(text_token_string) - len(phrase_token_match)) < token_searcher.config['max_length_variance']:
+            print(f"        get_token_skip_match_type - above max length variance, match_type:", match_type)
+    elif abs(len(text_token_string) - len(phrase_token_match)) <= token_searcher.config['max_token_length_variance']:
         match_type = MatchType.FULL
         if debug > 1:
-            print(f"get_token_skip_match_type - text and phrase tokens equal length, match_type:", match_type)
+            print(f"        get_token_skip_match_type - text and phrase tokens equal length, match_type:", match_type)
     elif len(text_token_string) < len(phrase_token_match):
         match_type = MatchType.PARTIAL_OF_PHRASE_TOKEN
         if debug > 1:
-            print(f"get_token_skip_match_type - phrase token longer than text token, match_type:", match_type)
+            print(f"        get_token_skip_match_type - phrase token longer than text token, match_type:", match_type)
     else:
         match_type = MatchType.PARTIAL_OF_TEXT_TOKEN
         if debug > 1:
-            print(f"get_token_skip_match_type - text token longer than phrase token, match_type:", match_type)
+            print(f"        get_token_skip_match_type - text token longer than phrase token, match_type:", match_type)
     return match_type

--- a/fuzzy_search/tokenization/string.py
+++ b/fuzzy_search/tokenization/string.py
@@ -154,6 +154,10 @@ class SkipGram:
         self.end_offset = end_offset
         self.length = skipgram_length
 
+    def __repr__(self):
+        return (f"{self.__class__.__name__}(string='{self.string}', start_offset={self.start_offset}, "
+                f"end_offset={self.end_offset}, length={self.length}")
+
 
 def insert_skips(window: str, skipgram_combinations: List[List[int]]):
     """For a given skip gram window, return all skip grams for a given configuration."""
@@ -170,7 +174,7 @@ def insert_skips(window: str, skipgram_combinations: List[List[int]]):
 def text2skipgrams(text: str, ngram_size: int = 2, skip_size: int = 2) -> Generator[SkipGram, None, None]:
     """Turn a text string into a list of skipgrams.
 
-    :param text: an text string
+    :param text: a text string
     :type text: str
     :param ngram_size: an integer indicating the number of characters in the ngram
     :type ngram_size: int
@@ -180,13 +184,19 @@ def text2skipgrams(text: str, ngram_size: int = 2, skip_size: int = 2) -> Genera
     :rtype: Generator[tuple]"""
     if ngram_size <= 0 or skip_size < 0:
         raise ValueError('ngram_size must be a positive integer, skip_size must be a positive integer or zero')
-    indexes = [i for i in range(0, ngram_size+skip_size)]
-    skipgram_combinations = [combination for combination in combinations(indexes[1:], ngram_size-1)]
-    for start_offset in range(0, len(text)-1):
-        end_offset = len(text) - start_offset
-        window = text[start_offset:start_offset+ngram_size+skip_size]
-        for skipgram, skipgram_length in insert_skips(window, skipgram_combinations):
-            yield SkipGram(skipgram, start_offset, end_offset, skipgram_length)
+    if ngram_size == 1:
+        for char in text:
+            yield SkipGram(char, 0, 1, 1)
+    elif len(text) <= ngram_size:
+        yield SkipGram(text, 0, len(text), len(text))
+    else:
+        indexes = [i for i in range(0, ngram_size + skip_size)]
+        skipgram_combinations = [combination for combination in combinations(indexes[1:], ngram_size - 1)]
+        for start_offset in range(0, len(text)):
+            end_offset = len(text) - start_offset
+            window = text[start_offset:start_offset+ngram_size+skip_size]
+            for skipgram, skipgram_length in insert_skips(window, skipgram_combinations):
+                yield SkipGram(skipgram, start_offset, end_offset, skipgram_length)
 
 
 non_word_affixes_2 = {

--- a/fuzzy_search/tokenization/token.py
+++ b/fuzzy_search/tokenization/token.py
@@ -541,3 +541,13 @@ def update_token(token: Token, new_normalised: str) -> Token:
     return Token(string=token.t, index=token.i, char_index=token.char_index,
                  normalised_string=new_normalised,
                  metadata=copy.deepcopy(token.metadata))
+
+
+def tokens2string(tokens: List[Token]) -> str:
+    string = ''
+    for token in tokens:
+        if token.char_index > len(string):
+            diff = token.char_index - len(string)
+            string += ' ' * diff
+        string += token.t
+    return string

--- a/test/test_phrase_phrase.py
+++ b/test/test_phrase_phrase.py
@@ -46,9 +46,17 @@ class TestFuzzyPhrase(TestCase):
         phrase = Phrase({"phrase": "some phrase", "max_start_offset": 3})
         self.assertEqual(phrase.max_start_offset, 3)
 
+    def test_fuzzy_phrase_can_check_if_max_start_offset(self):
+        phrase = Phrase({"phrase": "some phrase", "max_start_offset": 3})
+        self.assertEqual(True, phrase.has_max_start_offset())
+
     def test_fuzzy_phrase_can_set_max_start_end(self):
         phrase = Phrase({"phrase": "some phrase", "max_start_offset": 3})
         self.assertEqual(phrase.max_start_end, 3 + len("some_phrase"))
+
+    def test_fuzzy_phrase_can_check_if_max_end_offset(self):
+        phrase = Phrase({"phrase": "some phrase", "max_end_offset": 3})
+        self.assertEqual(True, phrase.has_max_end_offset())
 
     def test_fuzzy_phrase_cannot_set_negative_max_start_offset(self):
         error = None

--- a/test/test_phrase_phrase_model.py
+++ b/test/test_phrase_phrase_model.py
@@ -88,11 +88,45 @@ class TestPhraseModelTokenizer(TestCase):
 
     def setUp(self) -> None:
         self.tokenizer = Tokenizer()
-        self.phrase = 'this is a test'
-        self.phrases = [{"phrase": "this is a test"}]
+        self.phrase = 'this is a test with a repetition of test'
+        self.phrases = [{"phrase": self.phrase}]
         self.phrase_model = PhraseModel(phrases=self.phrases, tokenizer=self.tokenizer)
 
     def test_can_add_tokenizer_at_init(self):
         phrase_model = PhraseModel(phrases=self.phrases, tokenizer=self.tokenizer)
         tokens = self.tokenizer.tokenize(self.phrase)
         self.assertEqual(True, phrase_model.has_token(tokens[0]))
+
+    def test_phrase_model_indexes_phrase_token_min_offset(self):
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[3]
+        self.assertEqual(test_token.char_index, self.phrase_model.min_token_offset_in_phrase[test_token.n][self.phrase])
+
+    def test_phrase_model_indexes_phrase_token_max_offset(self):
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[8]
+        self.assertEqual(test_token.char_index, self.phrase_model.max_token_offset_in_phrase[test_token.n][self.phrase])
+
+    def test_phrase_model_indexes_no_phrase_token_max_start_offset(self):
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[8]
+        self.assertEqual(False, test_token.n in self.phrase_model.phrase_token_max_start_offset)
+
+    def test_phrase_model_indexes_phrase_token_max_start_offset(self):
+        phrases = [{"phrase": self.phrase, 'max_start_offset': 10}]
+        phrase_model = PhraseModel(phrases=phrases, tokenizer=self.tokenizer)
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[8]
+        self.assertEqual(True, test_token.n in phrase_model.phrase_token_max_start_offset)
+
+    def test_phrase_model_indexes_no_phrase_token_max_end_offset(self):
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[8]
+        self.assertEqual(False, test_token.n in self.phrase_model.phrase_token_max_end_offset)
+
+    def test_phrase_model_indexes_phrase_token_max_end_offset(self):
+        phrases = [{"phrase": self.phrase, 'max_end_offset': 10}]
+        phrase_model = PhraseModel(phrases=phrases, tokenizer=self.tokenizer)
+        tokens = self.tokenizer.tokenize(self.phrase)
+        test_token = tokens[8]
+        self.assertEqual(True, test_token.n in phrase_model.phrase_token_max_end_offset)

--- a/test/test_tokenization_string.py
+++ b/test/test_tokenization_string.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from fuzzy_search.tokenization.string import make_ngrams, score_char_overlap
 from fuzzy_search.tokenization.string import score_ngram_overlap
 from fuzzy_search.tokenization.string import score_levenshtein_similarity_ratio
+from fuzzy_search.tokenization.string import text2skipgrams
 
 
 class Test(TestCase):
@@ -30,6 +31,14 @@ class Test(TestCase):
         error = None
         try:
             make_ngrams('test', -1)
+        except ValueError as err:
+            error = err
+        self.assertNotEqual(error, None)
+
+    def test_make_ngrams_rejects_zero_size(self):
+        error = None
+        try:
+            make_ngrams('test', 0)
         except ValueError as err:
             error = err
         self.assertNotEqual(error, None)
@@ -99,3 +108,26 @@ class Test(TestCase):
         text = 'test'
         similarity = score_levenshtein_similarity_ratio(text, text)
         self.assertEqual(similarity, 1)
+
+
+class TestText2SkipGrams(TestCase):
+
+    def test_text2skipgrams_rejects_n_below_1(self):
+        error = None
+        try:
+            _ = [_ for _ in text2skipgrams('test', ngram_size=0)]
+        except ValueError as err:
+            error = err
+        self.assertNotEqual(None, error)
+
+    def test_text2skipgrams_accepts_n_1(self):
+        skips = [sg for sg in text2skipgrams('test', ngram_size=1)]
+        self.assertEqual(4, len(skips))
+
+    def test_text2skipgrams_returns_string_if_smaller_than_ngram_size(self):
+        skips = [sg for sg in text2skipgrams('t', ngram_size=2)]
+        self.assertEqual(1, len(skips))
+
+    def test_text2skipgrams_returns_string_if_equal_ngram_size(self):
+        skips = [sg for sg in text2skipgrams('te', ngram_size=2)]
+        self.assertEqual(1, len(skips))

--- a/test/test_tokenization_token.py
+++ b/test/test_tokenization_token.py
@@ -4,6 +4,7 @@ from fuzzy_search.tokenization.token import Token
 from fuzzy_search.tokenization.token import Doc
 from fuzzy_search.tokenization.token import Tokenizer
 from fuzzy_search.tokenization.token import CustomTokenizer
+from fuzzy_search.tokenization.token import tokens2string
 
 
 class TestToken(TestCase):
@@ -101,3 +102,16 @@ class TestCustomTokenizer(TestCase):
         for ti, token in enumerate(tokens):
             with self.subTest(ti):
                 self.assertEqual(token, custom_tokens[ti].t)
+
+
+class TestToken2String(TestCase):
+
+    def setUp(self) -> None:
+        self.string = "Yeah, well, you know, that's just like, uh, your opinion, man."
+        self.tokenizer = Tokenizer()
+        self.tokens = self.tokenizer.tokenize(self.string)
+
+    def test_text2string_can_reconstruct_original_string(self):
+        new_string = tokens2string(self.tokens)
+        self.assertEqual(new_string, self.string)
+


### PR DESCRIPTION
- Fix bug where `FuzzyTokenSearcher` fails on very short tokens.
- Update `FuzzyTokenSearcher` to properly use variants of phrases.
- Ensure that `FuzzyTokenSearcher` sticks to max start and end offsets.
- Fix bug in `FuzzyTokenSearcher` that considers only first alternative in sequence of matched text tokens.
- Update `FuzzyTokenSearcher` to different between a max length variance of phrases and of tokens.
- Fix bug in `FuzzyTokenSearcher` that ignores non-matched terms in strings that can still be good phrase matches.
- Fix bug in `text2skipgrams` that ignored words smaller than `ngram_size`
- Update `text2skipgrams` to allow `ngram_size=1`

The `FuzzyTokenSearcher` is now slower, but I'm planning a speed up by keeping track of common matches and non-matches.